### PR TITLE
SQLite is available on AWS Python 3.7 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ implications on what libaries will be available to you, notably:
 
 - PostgreSQL, so psycopg2 won't work out of the box
 - MySQL, so MySQL adapters won't work out of the box either
-- Sqlite, so the built-in Sqlite adapter won't be available
 
 
 ## Contributing


### PR DESCRIPTION
https://now-2-asgi-hello-world.now.sh/  shows SQLite version 3.7.17 is available.

Source code: https://gist.github.com/simonw/7027cdc1f7df3821c88da13314cce277